### PR TITLE
Partial learner, parser and converter logics 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>kakumara</groupId>
+    <artifactId>glalaxy-merchant</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <version>4.12</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/org/kakumara/galaxymerchant/Learner.java
+++ b/src/main/java/org/kakumara/galaxymerchant/Learner.java
@@ -1,0 +1,62 @@
+package org.kakumara.galaxymerchant;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.kakumara.galaxymerchant.RomanNumber.romanNumber;
+
+public class Learner {
+
+    static final ConcurrentMap<RomanDigit, List<String>> ROMAN_DIGIT_LITERALS = new ConcurrentHashMap<>();
+    static final ConcurrentMap<String, Double> METAL_PRICES = new ConcurrentHashMap<>();
+
+    public void feed(Statement statement) {
+        if (statement.isLiteralUpdate()) {
+            updateDigitLiterals(statement.getRoman(), statement.getTokens().get(0));
+        } else if (statement.isRateAdjustment()) {
+            updateMetalPrices(statement.getTokens(), statement.getCreditValue());
+        }
+    }
+
+    public Optional<String> ask(Statement query) {
+        if(query.isQuery()){
+            List<String> tokensWithMetal = query.getTokens();
+            String metal = tokensWithMetal.get(tokensWithMetal.size() - 1);
+            String romanString = makeRomanString(tokensWithMetal);
+            Integer noOfUnits = romanNumber(romanString).toInt();
+            Double price = METAL_PRICES.get(metal) * noOfUnits;
+            return  Optional.of(String.valueOf(price.intValue()));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private  void updateMetalPrices(List<String> tokensWithMetal, Integer creditForUnits) {
+        String metal = tokensWithMetal.get(tokensWithMetal.size() - 1);
+        String romanString = makeRomanString(tokensWithMetal);
+
+        Integer noOfUnits = romanNumber(romanString).toInt();
+        METAL_PRICES.put(metal, (double) (creditForUnits / noOfUnits));
+    }
+
+    private String makeRomanString(List<String> tokensWithMetal) {
+        List<String> tokens = tokensWithMetal.subList(0, tokensWithMetal.size() - 1);
+        StringBuffer romanString = new StringBuffer();
+
+        tokens.stream().flatMap(token ->
+                ROMAN_DIGIT_LITERALS.entrySet().stream()
+                        .filter(literalEntry -> literalEntry.getValue().contains(token))
+                        .map(entry -> entry.getKey().name()))
+                .forEach(literal -> romanString.append(literal));
+        return romanString.toString();
+    }
+
+    private void updateDigitLiterals(RomanDigit roman, String literal) {
+        List<String> literals = ROMAN_DIGIT_LITERALS.getOrDefault(roman, new ArrayList<>());
+        literals.add(literal);
+        ROMAN_DIGIT_LITERALS.put(roman, literals);
+    }
+}

--- a/src/main/java/org/kakumara/galaxymerchant/QueryParser.java
+++ b/src/main/java/org/kakumara/galaxymerchant/QueryParser.java
@@ -1,0 +1,59 @@
+package org.kakumara.galaxymerchant;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Optional.empty;
+import static java.util.regex.Pattern.compile;
+import static org.kakumara.galaxymerchant.RomanDigit.romanDigitOf;
+import static org.kakumara.galaxymerchant.Statement.query;
+import static org.kakumara.galaxymerchant.Statement.statement;
+
+public class QueryParser {
+
+    static final Pattern validQueryPattern = compile("how\\s+(many|much)(\\s+credits)?\\s+(is)\\s+(.*)\\s+(\\?)");
+
+    static final Set<Pattern> validStatementPatterns = new HashSet<Pattern>() {{
+        add(compile("(.*)\\s+(is)\\s+(i|v|x|l|c|d|m)"));
+        add(compile("(.*)\\s+(is)\\s+(\\d+)\\s+(credits)"));
+    }};
+
+    public Optional<Statement> parse(String queryString) {
+        String formattedInput = queryString.trim().toLowerCase().replaceAll("\\s+", " ");
+        Matcher queryMatcher = validQueryPattern.matcher(formattedInput);
+
+        if (queryMatcher.matches()) {
+            return Optional.of(query(tokenizeInput(queryMatcher, queryMatcher.groupCount() - 1)));
+        }
+
+        for (Pattern pattern : validStatementPatterns) {
+            Matcher stmtMatcher = pattern.matcher(formattedInput);
+            if (stmtMatcher.matches()) {
+                String value = stmtMatcher.group(3);
+                String[] tokens = tokenizeInput(stmtMatcher, 1);
+                return isNumeric(value)
+                        .map(creditValue -> Optional.of(statement(tokens, creditValue)))
+                        .orElseGet(() ->
+                                RomanDigit.isRoman(value) ?
+                                        Optional.of(statement(tokens, romanDigitOf(value))) : empty()
+                        );
+            }
+        }
+        return empty();
+    }
+
+    private String[] tokenizeInput(Matcher matcher, int groupIdx) {
+        return matcher.group(groupIdx).split(" ");
+    }
+
+    private Optional<Integer> isNumeric(String value) {
+        try {
+            return Optional.of(Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            return empty();
+        }
+    }
+}

--- a/src/main/java/org/kakumara/galaxymerchant/RomanDigit.java
+++ b/src/main/java/org/kakumara/galaxymerchant/RomanDigit.java
@@ -1,0 +1,38 @@
+package org.kakumara.galaxymerchant;
+
+import java.util.EnumSet;
+
+import static java.lang.String.format;
+
+public enum RomanDigit {
+    I(1), V(5), X(10), L(50), C(100), D(500), M(1000);
+
+    private final int value;
+
+    RomanDigit(int value) {
+        this.value = value;
+    }
+
+    public int decimalValue() {
+        return value;
+    }
+
+    public static RomanDigit romanDigitOf(String romanChar) {
+        for (RomanDigit romanDigit : EnumSet.allOf(RomanDigit.class)) {
+            if (romanDigit.name().equals(romanChar.toUpperCase())) {
+                return romanDigit;
+            }
+        }
+        throw new IllegalArgumentException(format("%s not a valid romanDigitOf numeral", romanChar));
+    }
+
+    public static boolean isRoman(String romanChar) {
+        try {
+            romanDigitOf(romanChar);
+            return true;
+        } catch (IllegalArgumentException e){
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/org/kakumara/galaxymerchant/RomanNumber.java
+++ b/src/main/java/org/kakumara/galaxymerchant/RomanNumber.java
@@ -1,0 +1,58 @@
+package org.kakumara.galaxymerchant;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static java.util.Arrays.copyOf;
+import static org.kakumara.galaxymerchant.RomanDigit.*;
+
+public class RomanNumber {
+
+    public static RomanNumber romanNumber(String romanString) {
+        return new RomanNumber(romanString);
+    }
+
+private static final Pattern CONSECUTIVE_CHARS = Pattern.compile("(.*)\\1\\1\\1");
+
+    private static final Map<RomanDigit, RomanDigit> VALID_PRE_DIGITS = new HashMap<RomanDigit, RomanDigit>() {{
+        put(V, I);
+        put(X, I);
+        put(L, X);
+        put(C, X);
+        put(D, C);
+        put(M, C);
+    }};
+    private final String romanString;
+
+    RomanNumber(String romanString) {
+        if(CONSECUTIVE_CHARS.matcher(romanString).matches()){
+            throw new NumberFormatException("You cannot have 4 consecutive roman literals");
+        }
+        this.romanString = romanString;
+    }
+
+    public Integer toInt() {
+        return convert(romanString.toCharArray(), 0);
+    }
+
+    private Integer convert(char[] romanChars, int total) {
+        if (romanChars.length == 1) {
+            char lastChar = romanChars[0];
+            return total + romanDigitOf(String.valueOf(lastChar)).decimalValue();
+        } else {
+            RomanDigit lastRoman = romanDigitOf(String.valueOf(romanChars[romanChars.length - 1]));
+            RomanDigit prevRoman = romanDigitOf(String.valueOf(romanChars[romanChars.length - 2]));
+
+            if (prevRoman.equals(VALID_PRE_DIGITS.get(lastRoman))) {
+                total += (lastRoman.decimalValue() - prevRoman.decimalValue());
+                if (romanChars.length == 2) {
+                    return total;
+                } else {
+                    return convert(copyOf(romanChars, romanChars.length - 2), total);
+                }
+            }
+            return convert(copyOf(romanChars, romanChars.length - 1), total + lastRoman.decimalValue());
+        }
+    }
+}

--- a/src/main/java/org/kakumara/galaxymerchant/Statement.java
+++ b/src/main/java/org/kakumara/galaxymerchant/Statement.java
@@ -1,0 +1,55 @@
+package org.kakumara.galaxymerchant;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Statement {
+
+    private final List<String> tokens;
+    private Integer creditValue;
+    private final RomanDigit roman;
+    private boolean query;
+
+    public static Statement query(String[] tokens) {
+        return new Statement(Arrays.asList(tokens), true, null, null);
+    }
+
+    public static Statement statement(String[] tokens, Integer creditValue) {
+        return new Statement(Arrays.asList(tokens), false, creditValue, null);
+    }
+
+    public static Statement statement(String[] tokens, RomanDigit romanValue) {
+        return new Statement(Arrays.asList(tokens), false, null, romanValue);
+    }
+
+    private Statement(List<String> tokens, boolean isQuery, Integer creditValue, RomanDigit roman) {
+        this.query = isQuery;
+        this.tokens = tokens;
+        this.creditValue = creditValue;
+        this.roman = roman;
+    }
+
+    public List<String> getTokens() {
+        return tokens;
+    }
+
+    public boolean isQuery() {
+        return query;
+    }
+
+    public boolean isRateAdjustment() {
+        return creditValue != null;
+    }
+
+    public boolean isLiteralUpdate() {
+        return roman != null;
+    }
+
+    public Integer getCreditValue() {
+        return creditValue;
+    }
+
+    public RomanDigit getRoman() {
+        return roman;
+    }
+}

--- a/src/test/java/org/kakumara/galaxymerchant/LearnerTest.java
+++ b/src/test/java/org/kakumara/galaxymerchant/LearnerTest.java
@@ -1,0 +1,56 @@
+package org.kakumara.galaxymerchant;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kakumara.galaxymerchant.RomanDigit.*;
+
+public class LearnerTest {
+
+    private Learner learner;
+
+    @Before
+    public void before() throws Exception {
+        learner = new Learner();
+        learner.feed(Statement.statement(new String[]{"aaa"}, I));
+        learner.feed(Statement.statement(new String[]{"bbb"}, V));
+        learner.feed(Statement.statement(new String[]{"ccc"}, X));
+        learner.feed(Statement.statement(new String[]{"ddd"}, L));
+        learner.feed(Statement.statement(new String[]{"fff"}, C));
+        learner.feed(Statement.statement(new String[]{"ggg"}, D));
+        learner.feed(Statement.statement(new String[]{"hhh"}, M));
+    }
+
+    @Test
+    public void shouldFeedIn_RateAdjustments_forValidStatements() throws Exception {
+
+        Statement rateAdjustment = Statement.statement(new String[]{"ccc", "aaa", "aaa", "Silver"}, 1200);
+        learner.feed(rateAdjustment);
+
+        assertThat(learner.METAL_PRICES.get("Silver"), is(100.0));
+    }
+
+    @Test
+    public void shouldDetermineCorrectMetalPrice() throws Exception {
+        Statement rateAdjustment = Statement.statement(new String[]{"ccc", "aaa", "aaa", "Silver"}, 1200);
+        learner.feed(rateAdjustment);
+
+        Optional<String> answer = learner.ask(Statement.query(new String[]{"fff", "aaa", "bbb", "Silver"}));
+        assertTrue(answer.isPresent());
+        assertThat(answer.get(), is("10400"));
+    }
+
+    @Test
+    public void shouldNotAnswerIfNotUnderstood() throws Exception {
+
+        Optional<String> answer = learner.ask(Statement.statement(new String[]{"fff", "aaa", "bbb", "Silver"}, 12));
+
+        assertFalse(answer.isPresent());
+    }
+}

--- a/src/test/java/org/kakumara/galaxymerchant/QueryParserTest.java
+++ b/src/test/java/org/kakumara/galaxymerchant/QueryParserTest.java
@@ -1,0 +1,72 @@
+package org.kakumara.galaxymerchant;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class QueryParserTest {
+
+    static final Boolean IS_A_QUERY = TRUE;
+    static final Boolean VALID = TRUE;
+    static final Boolean INVALID = FALSE;
+    static final Boolean IS_A_STATEMENT = FALSE;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"glob  is   I", VALID, IS_A_STATEMENT, 1},
+                {"prok   is   V", VALID, IS_A_STATEMENT, 1},
+                {"pish is X", VALID, IS_A_STATEMENT, 1},
+                {"tegj is L", VALID, IS_A_STATEMENT, 1},
+                {"glob  glob  Silver  is 34  Credits ", VALID, IS_A_STATEMENT, 3},
+                {"glob prok Gold is 57800 Credits", VALID, IS_A_STATEMENT, 3},
+                {"pish pish Iron is 3910 Credits", VALID, IS_A_STATEMENT, 3},
+                {"how much is pish tegj glob glob ?", VALID, IS_A_QUERY, 4},
+                {"how much is pish tegj glob glob ?", VALID, IS_A_QUERY, 4},
+                {"how   many Credits is glob prok Silver ?", VALID, IS_A_QUERY, 3},
+                {"how many Credits is glob prok Gold ?", VALID, IS_A_QUERY, 3},
+                {"how many Credits is glob prok Iron ?", VALID, IS_A_QUERY, 3},
+                {"how much wood could a woodchuck chuck if a woodchuck could chuck wood ?", INVALID, FALSE, 0}
+        });
+    }
+
+    @Parameter
+    public String statement;
+
+    @Parameter(1)
+    public Boolean expectedValid;
+
+    @Parameter(2)
+    public Boolean isQuery;
+
+    @Parameter(3)
+    public Integer expectedNoOfTokens;
+
+    @Test
+    public void shouldParseQueriesCorrectly() throws Exception {
+        QueryParser queryParser = new QueryParser();
+        Optional<Statement> statementOptional = queryParser.parse(statement);
+        if (expectedValid) {
+            assertTrue(statementOptional.isPresent());
+            assertThat(statementOptional.get().isQuery(), is(isQuery));
+            assertThat(statementOptional.get().getTokens().size(), is(expectedNoOfTokens));
+        } else {
+            assertFalse(statementOptional.isPresent());
+        }
+    }
+
+}

--- a/src/test/java/org/kakumara/galaxymerchant/RomanNumberTest.java
+++ b/src/test/java/org/kakumara/galaxymerchant/RomanNumberTest.java
@@ -1,0 +1,52 @@
+package org.kakumara.galaxymerchant;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.kakumara.galaxymerchant.RomanNumber.romanNumber;
+
+
+@RunWith(Parameterized.class)
+public class RomanNumberTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"I", 1},
+                {"II", 2},
+                {"X", 10},
+                {"VIII", 8},
+                {"XII", 12},
+                {"IX", 9},
+                {"IV", 4},
+                {"XXX", 30},
+                {"XLIV", 44},
+                {"XLVI", 46},
+                {"XC", 90},
+                {"D", 500},
+                {"CD", 400},
+                {"CM", 900},
+                {"CMXCIX", 999},
+                {"MCIII", 1103},
+                {"MMM", 3000}
+        });
+    }
+
+    @Parameterized.Parameter
+    public String roman;
+
+    @Parameterized.Parameter(1)
+    public Integer decimal;
+
+    @Test
+    public void shouldConvertRomanToDecimal() throws Exception {
+        assertThat(romanNumber(roman).toInt(), is(decimal));
+    }
+}
+

--- a/src/test/java/org/kakumara/galaxymerchant/RomanNumberValidationsTest.java
+++ b/src/test/java/org/kakumara/galaxymerchant/RomanNumberValidationsTest.java
@@ -1,0 +1,31 @@
+package org.kakumara.galaxymerchant;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class RomanNumberValidationsTest {
+
+    @Test(expected = NumberFormatException.class)
+    public void shouldNotAllow4ConsecutiveChars() throws Exception {
+        RomanNumber.romanNumber("XXXX");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void shouldNotAllow4ConsecutiveChars_2() throws Exception {
+        RomanNumber.romanNumber("IIII");
+    }
+
+    @Ignore("D,L,V should not be allowed to repeat twice. Need to find the correct regex")
+    @Test(expected = NumberFormatException.class)
+    public void shouldNotAllow4ConsecutiveChars_3() throws Exception {
+        RomanNumber.romanNumber("DD");
+    }
+
+    @Test
+    public void shouldAllowThreeConsecutiveChars() throws Exception {
+        assertThat( RomanNumber.romanNumber("XXX").toInt(), is(30));
+    }
+}


### PR DESCRIPTION
This PR contains;
- Core parser logic which parses both statement style and query style strings
 - Core learner and number converter logic

This is not complete yet. Few more things to come.

1. Handle RomanNumber converter's D,L,V do-not-repeat cases
2. learner ask should handle both metal price queries and number conversion queries. Currently only handles the metal price conversions
3. More tests cases (particularly corner cases)